### PR TITLE
Omit argument label of `removeFirst`

### DIFF
--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Partial RangeReplaceableCollection.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Partial RangeReplaceableCollection.swift
@@ -76,7 +76,7 @@ extension IdentifiedArray {
   ///   elements in the collection.
   /// - Complexity: O(`count`).
   @inlinable
-  public mutating func removeFirst(n: Int) {
+  public mutating func removeFirst(_ n: Int) {
     self._dictionary.removeFirst(n)
   }
 


### PR DESCRIPTION
Instead of `removeFirst(n:)`, use `removeFirst(_:)`.

Just like the RangeReplaceableCollection.
https://developer.apple.com/documentation/swift/rangereplaceablecollection/3018284-removefirst