### PR TITLE
Relax Swift Collections dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-collections", from: "0.0.4"),
+    .package(url: "https://github.com/apple/swift-collections", from: "0.0.1"),
     .package(url: "https://github.com/apple/swift-collections-benchmark", from: "0.0.2"),
   ],
   targets: [


### PR DESCRIPTION
We don't depend on anything that's come after 0.0.1, so we shouldn't require downstream consumers that use both libraries to upgrade to 0.0.4.