### PR TITLE
Fix partition

### DIFF
--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Partial MutableCollection.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Partial MutableCollection.swift
@@ -16,7 +16,9 @@ extension IdentifiedArray {
   public mutating func partition(
     by belongsInSecondPartition: (Element) throws -> Bool
   ) rethrows -> Int {
-    try self._dictionary.values.partition(by: belongsInSecondPartition)
+    try self._dictionary.partition { (_, value) in
+      try belongsInSecondPartition(value)
+    }
   }
 
   /// Reverses the elements of the array in place.

--- a/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
+++ b/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
@@ -177,6 +177,19 @@ final class IdentifiedArrayTests: XCTestCase {
     XCTAssertEqual(array, [0, 1, 2, 3])
   }
 
+  func testPartition() {
+    var array: IdentifiedArray = [1, 2]
+
+    let index = array.partition { $0.id == 1 }
+
+    XCTAssertEqual(index, 1)
+    XCTAssertEqual(array, [2, 1])
+
+    for id in array.ids {
+      XCTAssertEqual(id, array[id: id]?.id)
+    }
+  }
+
   #if canImport(SwiftUI)
     func testMoveFromOffsetsToOffset() {
       var array: IdentifiedArray = [1, 2, 3]


### PR DESCRIPTION
The partition implementation was swapping the values rather than calling through to OrderedArray's partition. This led to the invariant of the key equaling the id of the value being broken.

The test only uses two elements since I think partition is unstable and so using more elements would make checking equality of the collections more complex.