### PR TITLE
Add read-only `elements` getter to `IdentifiedArray`

### DIFF
--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray.swift
@@ -314,6 +314,13 @@ public struct IdentifiedArray<ID, Element> where ID: Hashable {
   @inline(__always)
   public var ids: OrderedSet<ID> { self._dictionary.keys }
 
+  /// A read-only collection view for the elements contained in this array, as an `Array`.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @inline(__always)
+  public var elements: [Element] { self._dictionary.values.elements }
+
   @usableFromInline
   init(
     id: KeyPath<Element, ID>,

--- a/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
+++ b/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
@@ -4,18 +4,28 @@ import XCTest
 
 extension Int: Identifiable { public var id: Self { self } }
 
+private struct User: Equatable, Identifiable {
+  let id: Int
+  var name: String
+}
+
 final class IdentifiedArrayTests: XCTestCase {
   func testIds() {
     let array: IdentifiedArray = [1, 2, 3]
     XCTAssertEqual(array.ids, [1, 2, 3])
   }
 
-  func testSubscriptId() {
-    struct User: Equatable, Identifiable {
-      let id: Int
-      var name: String
-    }
+  func testElements() {
+    let array: IdentifiedArray = [
+      User(id: 1, name: "Blob"),
+      User(id: 2, name: "Blob, Jr."),
+      User(id: 3, name: "Blob, Sr."),
+    ]
 
+    XCTAssertEqual(array.elements, array.map { $0 })
+  }
+
+  func testSubscriptId() {
     var array: IdentifiedArray = [
       User(id: 1, name: "Blob"),
       User(id: 2, name: "Blob, Jr."),


### PR DESCRIPTION
Until now there was no public API to efficiently return the elements from the underlying storage of `IdentifiedArray` as an `[Element]`, requiring an `O(n)` `map { $0 }` via `Collection` to achieve this.

By taking advantage of the existing `O(1)` `OrderedDictionary.values` and `OrderedDictionary.Values.elements` getters, we can efficiently provide an `O(1)` read-only view of the elements in a more ergonomic way.

## Changes

- Add new read-only `elements` getter to `IdentifiedArray`.