### PR TITLE
Bring IndexSet from Foundation

### DIFF
--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Partial MutableCollection.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Partial MutableCollection.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 extension IdentifiedArray {
   /// Reorders the elements of the array such that all the elements that match the given predicate
   /// are after all the elements that don't match.
@@ -106,6 +108,30 @@ extension IdentifiedArray {
   public mutating func swapAt(_ i: Int, _ j: Int) {
     self._dictionary.swapAt(i, j)
   }
+
+  /// Moves all the elements at the specified offsets to the specified destination offset,
+  /// preserving ordering.
+  ///
+  /// - Parameters:
+  ///   - source: The offsets of all elements to be moved.
+  ///   - destination: The destination offset.
+  /// - Complexity: O(*n* log *n*), where *n* is the length of the collection.
+  @inlinable
+  public mutating func move(fromOffsets source: IndexSet, toOffset destination: Int) {
+    var removed: [Element] = []
+    var removedBeforeDestinationCount = 0
+
+    removed.reserveCapacity(source.count)
+    for index in source.reversed() {
+      removed.append(self.remove(at: index))
+      if destination > index {
+        removedBeforeDestinationCount += 1
+      }
+    }
+    for element in removed {
+      self.insert(element, at: destination - removedBeforeDestinationCount)
+    }
+  }
 }
 
 extension IdentifiedArray where Element: Comparable {
@@ -126,33 +152,3 @@ extension IdentifiedArray where Element: Comparable {
     self.sort(by: <)
   }
 }
-
-#if canImport(SwiftUI)
-  import SwiftUI
-
-  extension IdentifiedArray {
-    /// Moves all the elements at the specified offsets to the specified destination offset,
-    /// preserving ordering.
-    ///
-    /// - Parameters:
-    ///   - source: The offsets of all elements to be moved.
-    ///   - destination: The destination offset.
-    /// - Complexity: O(*n* log *n*), where *n* is the length of the collection.
-    @inlinable
-    public mutating func move(fromOffsets source: IndexSet, toOffset destination: Int) {
-      var removed: [Element] = []
-      var removedBeforeDestinationCount = 0
-
-      removed.reserveCapacity(source.count)
-      for index in source.reversed() {
-        removed.append(self.remove(at: index))
-        if destination > index {
-          removedBeforeDestinationCount += 1
-        }
-      }
-      for element in removed {
-        self.insert(element, at: destination - removedBeforeDestinationCount)
-      }
-    }
-  }
-#endif

--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Partial RangeReplaceableCollection.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Partial RangeReplaceableCollection.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 extension IdentifiedArray where Element: Identifiable, ID == Element.ID {
   /// Creates an empty array.
   ///
@@ -145,24 +147,18 @@ extension IdentifiedArray {
   public mutating func reserveCapacity(_ minimumCapacity: Int) {
     self._dictionary.reserveCapacity(minimumCapacity)
   }
-}
 
-#if canImport(SwiftUI)
-  import SwiftUI
-
-  extension IdentifiedArray {
-    /// Removes all the elements at the specified offsets from the collection.
-    ///
-    /// - Parameter offsets: The offsets of all elements to be removed.
-    /// - Complexity: O(*n*) where *n* is the length of the collection.
-    @inlinable
-    public mutating func remove(atOffsets offsets: IndexSet) {
-      for range in offsets.rangeView.reversed() {
-        self.removeSubrange(range)
-      }
+  /// Removes all the elements at the specified offsets from the collection.
+  ///
+  /// - Parameter offsets: The offsets of all elements to be removed.
+  /// - Complexity: O(*n*) where *n* is the length of the collection.
+  @inlinable
+  public mutating func remove(atOffsets offsets: IndexSet) {
+    for range in offsets.rangeView.reversed() {
+      self.removeSubrange(range)
     }
   }
-#endif
+}
 
 // MARK: - Deprecations
 

--- a/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
+++ b/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
@@ -200,17 +200,15 @@ final class IdentifiedArrayTests: XCTestCase {
     }
   }
 
-  #if canImport(SwiftUI)
-    func testMoveFromOffsetsToOffset() {
-      var array: IdentifiedArray = [1, 2, 3]
-      array.move(fromOffsets: [0, 2], toOffset: 1)
-      XCTAssertEqual(array, [1, 3, 2])
-    }
+  func testMoveFromOffsetsToOffset() {
+    var array: IdentifiedArray = [1, 2, 3]
+    array.move(fromOffsets: [0, 2], toOffset: 1)
+    XCTAssertEqual(array, [1, 3, 2])
+  }
 
-    func testRemoveAtOffsets() {
-      var array: IdentifiedArray = [1, 2, 3]
-      array.remove(atOffsets: [0, 2])
-      XCTAssertEqual(array, [2])
-    }
-  #endif
+  func testRemoveAtOffsets() {
+    var array: IdentifiedArray = [1, 2, 3]
+    array.remove(atOffsets: [0, 2])
+    XCTAssertEqual(array, [2])
+  }
 }


### PR DESCRIPTION
Hi folks,

I've noticed that some methods that require `IndexSet` were restricted to `SwiftUI` being present in order to be declared. I couldn't find any other reason other than `IndexSet` for this requirement to be tied to `SwiftUI`. It seems to me that it's just relying on `SwiftUI` transitively bringing `Foundation` instead of just importing it.

Unless there's any other reason for those to be tied, this should enable using this methods on other platforms.

Thanks!