### PR TITLE
Remove deprecated index subscript setter

### DIFF
--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Collection.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Collection.swift
@@ -15,10 +15,6 @@ extension IdentifiedArray: Collection {
   @inline(__always)
   public subscript(position: Int) -> Element {
     _read { yield self._dictionary[offset: position].value }
-    @available(
-      *, unavailable, message: "use the id-based subscript, instead, for in-place modification"
-    )
-    set { fatalError() }
   }
 
   /// Returns a new array containing the elements of the array that satisfy the given predicate.


### PR DESCRIPTION
A Swift compiler bug prevents this availability check from working in certain contexts, for example in TCA test store closures, so let's get rid of it entirely.