### PR TITLE
Use a half stable partition for move/remove performance

### DIFF
--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Partial MutableCollection.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Partial MutableCollection.swift
@@ -119,7 +119,7 @@ extension IdentifiedArray {
   @inlinable
   public mutating func move(fromOffsets source: IndexSet, toOffset destination: Int) {
     var destination = destination
-    let suffixStart = self.halfStablePartition { index, _ in
+    let suffixStart = self.halfStablePartition { index in
       if index < destination { destination -= 1 }
       return source.contains(index)
     }
@@ -132,26 +132,22 @@ extension IdentifiedArray {
   }
 
   @inlinable
-  mutating func halfStablePartition(isSuffixElement predicate: (Index, Element) -> Bool) -> Index {
-    guard var i = self.firstIndex(where: predicate) else {
-      return self.endIndex
-    }
+  mutating func halfStablePartition(isSuffixIndex: (Index) -> Bool) -> Index {
+    guard var i = self.firstIndex(where: isSuffixIndex)
+    else { return self.endIndex }
 
     var j = self.index(after: i)
     while j != self.endIndex {
-      if !predicate(j, self[j]) {
-        self.swapAt(i, j)
-        formIndex(after: &i)
-      }
+      if !isSuffixIndex(j) { self.swapAt(i, j); formIndex(after: &i) }
       formIndex(after: &j)
     }
     return i
   }
 
   @inlinable
-  func firstIndex(where predicate: (Index, Element) -> Bool) -> Index? {
-    for (index, element) in zip(self.indices, self) {
-      if predicate(index, element) {
+  func firstIndex(where predicate: (Index) -> Bool) -> Index? {
+    for index in self.indices {
+      if predicate(index) {
         return index
       }
     }

--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Partial MutableCollection.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Partial MutableCollection.swift
@@ -119,7 +119,7 @@ extension IdentifiedArray {
   @inlinable
   public mutating func move(fromOffsets source: IndexSet, toOffset destination: Int) {
     var destination = destination
-    let suffixStart = self.halfStablePartition { index in
+    let suffixStart = self._halfStablePartition { index in
       if index < destination { destination -= 1 }
       return source.contains(index)
     }
@@ -132,8 +132,8 @@ extension IdentifiedArray {
   }
 
   @inlinable
-  mutating func halfStablePartition(isSuffixIndex: (Index) -> Bool) -> Index {
-    guard var i = self.firstIndex(where: isSuffixIndex)
+  mutating func _halfStablePartition(isSuffixIndex: (Index) -> Bool) -> Index {
+    guard var i = self.indices.firstIndex(where: isSuffixIndex)
     else { return self.endIndex }
 
     var j = self.index(after: i)
@@ -142,16 +142,6 @@ extension IdentifiedArray {
       formIndex(after: &j)
     }
     return i
-  }
-
-  @inlinable
-  func firstIndex(where predicate: (Index) -> Bool) -> Index? {
-    for index in self.indices {
-      if predicate(index) {
-        return index
-      }
-    }
-    return nil
   }
 }
 

--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Partial RangeReplaceableCollection.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Partial RangeReplaceableCollection.swift
@@ -154,7 +154,7 @@ extension IdentifiedArray {
   /// - Complexity: O(*n*) where *n* is the length of the collection.
   @inlinable
   public mutating func remove(atOffsets offsets: IndexSet) {
-    let suffixStart = self.halfStablePartition { offsets.contains($0) }
+    let suffixStart = self._halfStablePartition { offsets.contains($0) }
     self.removeSubrange(suffixStart...)
   }
 }

--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Partial RangeReplaceableCollection.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Partial RangeReplaceableCollection.swift
@@ -154,9 +154,8 @@ extension IdentifiedArray {
   /// - Complexity: O(*n*) where *n* is the length of the collection.
   @inlinable
   public mutating func remove(atOffsets offsets: IndexSet) {
-    for range in offsets.rangeView.reversed() {
-      self.removeSubrange(range)
-    }
+    let suffixStart = self.halfStablePartition { index, _ in offsets.contains(index) }
+    self.removeSubrange(suffixStart...)
   }
 }
 

--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Partial RangeReplaceableCollection.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Partial RangeReplaceableCollection.swift
@@ -154,7 +154,7 @@ extension IdentifiedArray {
   /// - Complexity: O(*n*) where *n* is the length of the collection.
   @inlinable
   public mutating func remove(atOffsets offsets: IndexSet) {
-    let suffixStart = self.halfStablePartition { index, _ in offsets.contains(index) }
+    let suffixStart = self.halfStablePartition { offsets.contains($0) }
     self.removeSubrange(suffixStart...)
   }
 }

--- a/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
+++ b/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
@@ -42,6 +42,16 @@ final class IdentifiedArrayTests: XCTestCase {
     XCTAssertEqual(array[id: 3], User(id: 3, name: "Blob"))
     array[id: 3] = nil
     XCTAssertEqual(array[id: 3], nil)
+
+    array[id: 4] = User(id: 4, name: "Blob, Sr.")
+    XCTAssertEqual(
+      array,
+      [
+        User(id: 1, name: "Blob, Esq."),
+        User(id: 2, name: "Blob"),
+        User(id: 4, name: "Blob, Sr."),
+      ]
+    )
   }
 
   func testContainsElement() {

--- a/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
+++ b/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
@@ -212,8 +212,16 @@ final class IdentifiedArrayTests: XCTestCase {
 
   func testMoveFromOffsetsToOffset() {
     var array: IdentifiedArray = [1, 2, 3]
+    array.move(fromOffsets: [0, 2], toOffset: 0)
+    XCTAssertEqual(array, [1, 3, 2])
+
+    array = [1, 2, 3]
     array.move(fromOffsets: [0, 2], toOffset: 1)
     XCTAssertEqual(array, [1, 3, 2])
+
+    array = [1, 2, 3]
+    array.move(fromOffsets: [0, 2], toOffset: 2)
+    XCTAssertEqual(array, [2, 1, 3])
   }
 
   func testRemoveAtOffsets() {


### PR DESCRIPTION
@lorentey Commented here that we're using `move`/`remove` methods with pretty bad performance (which we knew):

https://github.com/apple/swift-collections/issues/66#issuecomment-891327430

I took this code (with minor changes) from here: https://stackoverflow.com/a/56693340