### PR TITLE
fix warnings with newer swift-collections dependency

### DIFF
--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Collection.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Collection.swift
@@ -14,7 +14,7 @@ extension IdentifiedArray: Collection {
   @inlinable
   @inline(__always)
   public subscript(position: Int) -> Element {
-    _read { yield self._dictionary[offset: position].value }
+    _read { yield self._dictionary.elements[position].value }
   }
 
   /// Returns a new array containing the elements of the array that satisfy the given predicate.

--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Insertions.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Insertions.swift
@@ -46,7 +46,7 @@ extension IdentifiedArray {
   @inlinable
   @discardableResult
   public mutating func update(_ item: Element, at i: Int) -> Element {
-    let old = self._dictionary[offset: i].key
+    let old = self._dictionary.elements[i].key
     precondition(
       _id(item) == old, "The replacement item must match the identity of the original"
     )


### PR DESCRIPTION
This bumps adjusts the API usage to not give warnings on newer versions (>=0.0.7)