### PR TITLE
Depend on Swift Collections 1.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-collections", from: "0.0.1"),
+    .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
     .package(url: "https://github.com/apple/swift-collections-benchmark", from: "0.0.2"),
   ],
   targets: [


### PR DESCRIPTION
Now that 1.0 is official, let's depend on it.