### PR TITLE
Remove the comparison of id (KeyPath) in IdentifiedArray Equatable

### DIFF
--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Equatable.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Equatable.swift
@@ -1,6 +1,6 @@
 extension IdentifiedArray: Equatable where Element: Equatable {
   @inlinable
   public static func == (lhs: Self, rhs: Self) -> Bool {
-    lhs.id == rhs.id && lhs.elementsEqual(rhs)
+    lhs.elementsEqual(rhs)
   }
 }

--- a/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
+++ b/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
@@ -229,4 +229,42 @@ final class IdentifiedArrayTests: XCTestCase {
     array.remove(atOffsets: [0, 2])
     XCTAssertEqual(array, [2])
   }
+  func testEquatable() {
+    struct Foo: Identifiable, Equatable {
+        var id: String = "id"
+        var value: String = "value"
+    }
+    // Create arrays using all of the initializers
+    var arrays: [IdentifiedArray<String, Foo>] = [
+        IdentifiedArray<String, Foo>(),
+        IdentifiedArray<String, Foo>(uncheckedUniqueElements: [], id: \.id),
+        IdentifiedArray<String, Foo>(uniqueElements: [], id: \.id),
+        IdentifiedArray<String, Foo>(uncheckedUniqueElements: []),
+        IdentifiedArray<String, Foo>(uniqueElements: [])
+    ]
+    arrays.forEach({ lhs in
+        arrays.forEach({ rhs in
+            XCTAssertEqual(lhs, rhs)
+        })
+    })
+    // add an element to each array
+    arrays.indices.forEach({
+        arrays[$0].append(Foo())
+    })
+    arrays.forEach({ lhs in
+        arrays.forEach({ rhs in
+            XCTAssertEqual(lhs, rhs)
+        })
+    })
+    // modify all arrays
+    arrays.indices.forEach({
+        arrays[$0].append(Foo(id: "id2", value: "\($0)"))
+    })
+    arrays.enumerated().forEach({ lhsIndex, lhs in
+        arrays.enumerated().forEach({ rhsIndex, rhs in
+            guard rhsIndex != lhsIndex else { return }
+            XCTAssertNotEqual(lhs, rhs)
+        })
+    })
+  }
 }


### PR DESCRIPTION
Remove the comparison of id (KeyPath) in IdentifiedArray Equatable

Resolves issue:
fix #24 IdentifiedArray Equatable issues due to KeyPath