### PR TITLE
Update swift-collections dependency to 1.0.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     )
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
+    .package(url: "https://github.com/apple/swift-collections", from: "1.0.2"),
     .package(url: "https://github.com/apple/swift-collections-benchmark", from: "0.0.2"),
   ],
   targets: [


### PR DESCRIPTION
This PR updates the swift collections dependency to 1.0.2. This should fix #26.

More information:
> "Fixed a value semantic violation in OrderedSet and OrderedDictionary that could result in some mutation methods corrupting shared copies of the same value, leading to subsequent crashes. (Issue #104)"

[https://github.com/apple/swift-collections/releases/tag/1.0.2](https://github.com/apple/swift-collections/releases/tag/1.0.2)