### PR TITLE
Add `Identified`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        webhook_url: 
+          - '${{ secrets.SLACK_PROJECT_CHANNEL_WEBHOOK_URL }}'
+          - '${{ secrets.SLACK_RELEASES_WEBHOOK_URL }}'
+    steps:
+      - name: Dump Github context
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - name: Slack Notification on SUCCESS
+        if: success()
+        uses: tokorom/action-slack-incoming-webhook@main
+        env:
+          INCOMING_WEBHOOK_URL: ${{ matrix.webhook_url }}
+        with:
+          text: swift-identified-collections ${{ github.event.release.tag_name}} has been released.
+          blocks: |
+            [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "swift-identified-collections ${{ github.event.release.tag_name}}"
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": ${{ toJSON(github.event.release.body) }}
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "${{ github.event.release.html_url }}"
+                }
+              }
+            ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,14 +22,14 @@ jobs:
         env:
           INCOMING_WEBHOOK_URL: ${{ matrix.webhook_url }}
         with:
-          text: swift-identified-collections ${{ github.event.release.tag_name}} has been released.
+          text: swift-identified-collections ${{ github.event.release.tag_name }} has been released.
           blocks: |
             [
               {
                 "type": "header",
                 "text": {
                   "type": "plain_text",
-                  "text": "swift-identified-collections ${{ github.event.release.tag_name}}"
+                  "text": "swift-identified-collections ${{ github.event.release.tag_name }}"
                 }
               },
               {

--- a/Sources/IdentifiedCollections/Identified/Identified.swift
+++ b/Sources/IdentifiedCollections/Identified/Identified.swift
@@ -1,0 +1,60 @@
+/// A wrapper around a value and a hashable identifier that conforms to identifiable.
+@dynamicMemberLookup
+public struct Identified<ID: Hashable, Value>: Identifiable {
+  public let id: ID
+  public var value: Value
+
+  /// Initializes an identified value from a given value and a hashable identifier.
+  ///
+  /// - Parameters:
+  ///   - value: A value.
+  ///   - id: A hashable identifier.
+  public init(_ value: Value, id: ID) {
+    self.id = id
+    self.value = value
+  }
+
+  /// Initializes an identified value from a given value and a function that can return a hashable
+  /// identifier from the value.
+  ///
+  ///    ```swift
+  ///     Identified(uuid, id: \.self)
+  ///    ```
+  ///
+  /// - Parameters:
+  ///   - value: A value.
+  ///   - id: A hashable identifier.
+  public init(_ value: Value, id: (Value) -> ID) {
+    self.init(value, id: id(value))
+  }
+
+  // NB: This overload works around a bug in key path function expressions and `\.self`.
+  /// Initializes an identified value from a given value and a function that can return a hashable
+  /// identifier from the value.
+  ///
+  ///    ```swift
+  ///     Identified(uuid, id: \.self)
+  ///    ```
+  ///
+  /// - Parameters:
+  ///   - value: A value.
+  ///   - id: A key path from the value to a hashable identifier.
+  public init(_ value: Value, id: KeyPath<Value, ID>) {
+    self.init(value, id: value[keyPath: id])
+  }
+
+  public subscript<Subject>(
+    dynamicMember keyPath: WritableKeyPath<Value, Subject>
+  ) -> Subject {
+    get { self.value[keyPath: keyPath] }
+    set { self.value[keyPath: keyPath] = newValue }
+  }
+}
+
+extension Identified: Decodable where ID: Decodable, Value: Decodable {}
+
+extension Identified: Encodable where ID: Encodable, Value: Encodable {}
+
+extension Identified: Equatable where Value: Equatable {}
+
+extension Identified: Hashable where Value: Hashable {}


### PR DESCRIPTION
This type is extracted from the Composable Architecture. It wasn't used in any TCA-specific APIs, but is useful when it comes to working with `Identifiable` APIs, of which Identified Collections is built around, so this is probably the better home for now.
