### PR TITLE
Add container protocol for generic constraints

### DIFF
--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray.swift
@@ -331,7 +331,9 @@ public struct IdentifiedArray<ID, Element> where ID: Hashable {
     self._id = _id
     self._dictionary = _dictionary
   }
+}
 
+extension IdentifiedArray: IdentifiedCollection {
   /// Accesses the value associated with the given id for reading and writing.
   ///
   /// This *id-based* subscript returns the element identified by the given id if found in the

--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedCollection.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedCollection.swift
@@ -1,0 +1,35 @@
+import OrderedCollections
+
+public protocol IdentifiedCollection {
+  associatedtype ID: Hashable
+  associatedtype Element
+
+  var id: KeyPath<Element, ID> { get }
+
+  @inlinable
+  @inline(__always)
+  var ids: OrderedSet<ID> { get }
+
+  @inlinable
+  @inline(__always)
+  var elements: [Element] { get }
+
+  @inlinable
+  @inline(__always)
+  subscript(id id: ID) -> Element? { get set }
+
+  @inlinable
+  func contains(_ element: Element) -> Bool
+
+  @inlinable
+  @inline(__always)
+  func index(id: ID) -> Int?
+
+  @inlinable
+  @discardableResult
+  mutating func remove(_ element: Element) -> Element?
+
+  @inlinable
+  @discardableResult
+  mutating func remove(id: ID) -> Element?
+}

--- a/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
+++ b/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 extension Int: Identifiable { public var id: Self { self } }
 
-private struct User: Equatable, Identifiable {
+struct User: Equatable, Identifiable {
   let id: Int
   var name: String
 }

--- a/Tests/IdentifiedCollectionsTests/IdentifiedCollectionTests.swift
+++ b/Tests/IdentifiedCollectionsTests/IdentifiedCollectionTests.swift
@@ -1,0 +1,31 @@
+import IdentifiedCollections
+import XCTest
+
+final class IdentifiedCollectionTests: XCTestCase {
+
+  func testDefault() {
+    let normal = MockContainer<Array<User>>(collection: [])
+    XCTAssertFalse(normal.get())
+  }
+
+  func testConstrained() {
+    let constrained = MockContainer<IdentifiedArrayOf<User>>(collection: [])
+    XCTAssertTrue(constrained.get())
+  }
+}
+
+private struct MockContainer<T: Collection> {
+  let collection: T
+}
+
+extension MockContainer {
+  func get() -> Bool {
+    return false
+  }
+}
+
+extension MockContainer where T: IdentifiedCollection {
+  func get() -> Bool {
+    return true
+  }
+}


### PR DESCRIPTION
Similar to swift protocols such as `Collection`, `Sequence`, etc.

This provides a protocol with the main functionality of `IdentifiedArray` for use in generic constraints for types which can support some protocol IdentifiedArray conforms to. (see example in tests using `T: Collection`), allowing types to provide specialized functionality for given containers.

Before continuing on the todo list below, I wanted to provide this simple sample to see if this is something that would be considered for merge. I am currently using a similar protocol in a project by extending `IdentifiedArray` to conform outside of this package, but figured it may be useful for others.

TODO:
- [ ] Consensus on protocol name
- [ ] Add other public functions (eg: initializers)
- [ ] Move documentation?
- [ ] Verify if `@` attributes are needed/desired in protocol
- [ ] Protocol type documentation