### PR TITLE
Added initializers for arbitrary arrays

### DIFF
--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Initializers.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Initializers.swift
@@ -38,8 +38,8 @@ extension IdentifiedArray {
   /// ids. Passing a sequence with duplicate ids to this initializer results in a runtime error.
   ///
   /// - Parameters:
-  ///   - elements: A sequence of elements to use for the new array. Every key in
-  ///     `keysAndValues` must be unique.
+  ///   - elements: A sequence of elements to use for the new array. Every key in `elements`
+  ///     must be unique.
   ///   - id: The key path to an element's identifier.
   /// - Returns: A new array initialized with the elements of `elements`.
   /// - Precondition: The sequence must not have duplicate ids.
@@ -187,7 +187,7 @@ extension IdentifiedArray where Element: Identifiable, ID == Element.ID {
   /// ids. Passing a sequence with duplicate ids to this initializer results in a runtime error.
   ///
   /// - Parameters elements: A sequence of elements to use for the new array. Every key in
-  ///   `keysAndValues` must be unique.
+  ///   `elements` must be unique.
   /// - Returns: A new array initialized with the elements of `elements`.
   /// - Precondition: The sequence must not have duplicate ids.
   /// - Complexity: Expected O(*n*) on average, where *n* is the count of elements, if `ID`

--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Initializers.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Initializers.swift
@@ -65,6 +65,64 @@ extension IdentifiedArray {
       _dictionary: .init(uniqueKeysWithValues: elements.lazy.map { ($0[keyPath: id], $0) })
     )
   }
+    
+    /// Creates a new array from the elements in the given sequence.
+    ///
+    /// You use this initializer to create an array when you have an arbitrary sequence of elements
+    /// that may not have unique ids. It's safe to pass a sequence with duplicate ids to this initializer,
+    /// later duplicated elements will be discarded.
+    ///
+    /// - Parameters:
+    ///   - elements: A sequence of elements to use for the new array. Every key in `elements`
+    ///     must be unique.
+    ///   - id: The key path to an element's identifier.
+    /// - Returns: A new array initialized with the unique elements of `elements`.
+    /// - Complexity: Expected O(*n*) on average, where *n* is the count of elements, if `ID`
+    ///   implements high-quality hashing.
+    @inlinable
+    public init<S>(
+        arbitraryElements elements: S,
+        id: KeyPath<Element, ID>
+    )
+    where S: Sequence, S.Element == Element {
+        self.init(
+            arbitraryElements: elements,
+            id: id,
+            uniquingWith: { l, _ in l }
+        )
+    }
+    
+    /// Creates a new array from the elements in the given sequence, using a combining closure to determine
+    ///  the element for any duplicate elements.
+    ///
+    /// You use this initializer to create an array when you have an arbitrary sequence of elements
+    /// that may not have unique ids. This initializer calls the combine closure with the current and
+    ///  new values for any duplicate ids. Pass a closure as combine that returns the value to use in
+    ///  the resulting dictionary: The closure can choose between the two values, combine them to produce
+    ///  a new value, or even throw an error.
+    ///
+    /// - Parameters:
+    ///   - elements: A sequence of elements to use for the new array. Every key in `elements`
+    ///     must be unique.
+    ///   - id: The key path to an element's identifier.
+    ///   - combine: Closure used to combine duplicated elements.
+    /// - Returns: A new array initialized with the unique elements of `elements`.
+    /// - Complexity: Expected O(*n*) on average, where *n* is the count of elements, if `ID`
+    ///   implements high-quality hashing.
+    public init<S: Sequence>(
+        arbitraryElements elements: S,
+        id: KeyPath<Element, ID>,
+        uniquingWith combine: (Element, Element) throws -> Element
+    ) rethrows where S.Element == Element {
+        try self.init(
+          id: id,
+          _id: { $0[keyPath: id] },
+          _dictionary: .init(
+            elements.lazy.map { ($0[keyPath: id], $0) },
+            uniquingKeysWith: combine
+          )
+        )
+    }
 
   /// Creates a new array from an existing array. This is functionally the same as copying the value
   /// of `elements` into a new variable.
@@ -150,6 +208,57 @@ extension IdentifiedArray where Element: Identifiable, ID == Element.ID {
       _dictionary: .init(uniqueKeysWithValues: elements.lazy.map { ($0.id, $0) })
     )
   }
+    
+    /// Creates a new array from the elements in the given sequence.
+    ///
+    /// You use this initializer to create an array when you have an arbitrary sequence of elements
+    /// that may not have unique ids. It's safe to pass a sequence with duplicate ids to this initializer,
+    /// later duplicated elements will be discarded.
+    ///
+    /// - Parameters:
+    ///   - elements: A sequence of elements to use for the new array. Every key in `elements`
+    ///     must be unique.
+    /// - Returns: A new array initialized with the unique elements of `elements`.
+    /// - Complexity: Expected O(*n*) on average, where *n* is the count of elements, if `ID`
+    ///   implements high-quality hashing.
+    @inlinable
+    public init<S>(arbitraryElements elements: S) where S: Sequence, S.Element == Element {
+        self.init(
+            arbitraryElements: elements,
+            uniquingWith: { l, _ in l }
+        )
+    }
+    
+    /// Creates a new array from the elements in the given sequence, using a combining closure to determine
+    ///  the element for any duplicate elements.
+    ///
+    /// You use this initializer to create an array when you have an arbitrary sequence of elements
+    /// that may not have unique ids. This initializer calls the combine closure with the current and
+    ///  new values for any duplicate ids. Pass a closure as combine that returns the value to use in
+    ///  the resulting dictionary: The closure can choose between the two values, combine them to produce
+    ///  a new value, or even throw an error.
+    ///
+    /// - Parameters:
+    ///   - elements: A sequence of elements to use for the new array. Every key in `elements`
+    ///     must be unique.
+    ///   - combine: Closure used to combine duplicated elements.
+    /// - Returns: A new array initialized with the unique elements of `elements`.
+    /// - Complexity: Expected O(*n*) on average, where *n* is the count of elements, if `ID`
+    ///   implements high-quality hashing.
+    @inlinable
+    public init<S: Sequence>(
+        arbitraryElements elements: S,
+        uniquingWith combine: (Element, Element) throws -> Element
+    ) rethrows where S.Element == Element {
+        try self.init(
+          id: \.id,
+          _id: { $0.id },
+          _dictionary: .init(
+            elements.lazy.map { ($0.id, $0) },
+            uniquingKeysWith: combine
+          )
+        )
+    }
 }
 
 // MARK: - Deprecations

--- a/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
+++ b/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
@@ -148,6 +148,82 @@ final class IdentifiedArrayTests: XCTestCase {
     let array: IdentifiedArray = [1, 2, 3]
     XCTAssertEqual(IdentifiedArray(array[...]), [1, 2, 3])
   }
+    
+    func testArbitraryInitId() {
+        let array = IdentifiedArray(arbitraryElements: ["A", "B", "C", "A"], id: \.self)
+        XCTAssertEqual(array, IdentifiedArray(uniqueElements: ["A", "B", "C"], id: \.self))
+    }
+    
+    func testArbitraryInitIdCombined() {
+        struct Model: Equatable {
+            let id: Int
+            let data: String
+        }
+        // Choose first element
+        do {
+            let array = IdentifiedArray(arbitraryElements: [
+                Model(id: 1, data: "A"),
+                Model(id: 2, data: "B"),
+                Model(id: 1, data: "AAAA"),
+            ], id: \.id, uniquingWith: { l, _ in l })
+            
+            XCTAssertEqual(array, IdentifiedArray(uniqueElements: [
+                Model(id: 1, data: "A"),
+                Model(id: 2, data: "B"),
+            ], id: \.id))
+        }
+        // Choose later element
+        do {
+            let array = IdentifiedArray(arbitraryElements: [
+                Model(id: 1, data: "A"),
+                Model(id: 2, data: "B"),
+                Model(id: 1, data: "AAAA"),
+            ], id: \.id, uniquingWith: { _, r in r })
+            
+            XCTAssertEqual(array, IdentifiedArray(uniqueElements: [
+                Model(id: 1, data: "AAAA"),
+                Model(id: 2, data: "B"),
+            ], id: \.id))
+        }
+    }
+    
+    func testArbitraryInit() {
+        let array = IdentifiedArray(arbitraryElements: [1, 2, 3, 1])
+        XCTAssertEqual(array, [1, 2, 3])
+    }
+    
+    func testArbitraryInitCombined() {
+        struct Model: Equatable, Identifiable {
+            let id: Int
+            let data: String
+        }
+        // Choose first element
+        do {
+            let array = IdentifiedArray(arbitraryElements: [
+                Model(id: 1, data: "A"),
+                Model(id: 2, data: "B"),
+                Model(id: 1, data: "AAAA"),
+            ], uniquingWith: { l, _ in l })
+            
+            XCTAssertEqual(array, IdentifiedArray(uniqueElements: [
+                Model(id: 1, data: "A"),
+                Model(id: 2, data: "B"),
+            ]))
+        }
+        // Choose later element
+        do {
+            let array = IdentifiedArray(arbitraryElements: [
+                Model(id: 1, data: "A"),
+                Model(id: 2, data: "B"),
+                Model(id: 1, data: "AAAA"),
+            ], uniquingWith: { _, r in r })
+            
+            XCTAssertEqual(array, IdentifiedArray(uniqueElements: [
+                Model(id: 1, data: "AAAA"),
+                Model(id: 2, data: "B"),
+            ]))
+        }
+    }
 
   func testAppend() {
     var array: IdentifiedArray = [1, 2, 3]


### PR DESCRIPTION
Hello,
This PR adds new initializers that accept an arbitrary array that may include elements with duplicated IDs which will be deduped in the resulting identified array.

## Motivation

Unfortunately is not uncommon to receive lists with unexpected duplicated IDs from backend APIs that are outside our control. In those cases the default and convenient usage of `IdentifiedArray` results in a runtime crash which is not good for the users.

To solve this the developer is forced to preemptively preprocess the array to remove duplicated and then initialize the `IdentifiedArray`. This can get cumbersome and may result in not ideal performance. A solution for this can be built outside the library as suggested by Stephen, and even though that's what I've done for now, I consider this a decently common scenario hence my proposing the inclusion of a solution in the library itself.

## 2 inits

The API I want to use in my code is the convenient form that accepts the arbitrary array and deduplicates it without me having to specify how to do it. In this my expectation is that the first added element is the one that takes priority, which surfaces from some common scenarios like paginating a BE API. 

But I admit that this may not be what everybody wants and may not be an API surface worth exposing in the library. For that reason the other init is similar to the one in `Dictionary` which allows the developer to decide how to resolve the conflicts (thanks Stephen for the suggestion). 

I've added both in this PR, the convenient built on top of the other one, but if the library authors prefer to keep only the dictionary-like init I'm happy to remove the other one and keep it as a helper in my code, even in that case being able to use a public init that doesn't crash and takes care of duplicates is a big win. 

## Docs

I've tried to replicate the docs that are already in the library with some changes where appropriate and taking some inspiration from the Dictionary docs. 

## Tests

I've written tests for all variants of the inits.

_[Slack thread](https://pointfreecommunity.slack.com/archives/C04L8MH1TM2/p1684395690689269)_