### PR TITLE
A few changes related to #58

### DIFF
--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Initializers.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Initializers.swift
@@ -66,53 +66,27 @@ extension IdentifiedArray {
     )
   }
 
-  /// Creates a new array from the elements in the given sequence.
+  /// Creates a new array from the elements in the given sequence, using a combining closure to
+  /// determine the element for any elements with duplicate identity.
   ///
   /// You use this initializer to create an array when you have an arbitrary sequence of elements
-  /// that may not have unique ids. It's safe to pass a sequence with duplicate ids to this initializer,
-  /// later duplicated elements will be discarded.
+  /// that may not have unique ids. This initializer calls the `combine` closure with the current
+  /// and new elements for any duplicate ids. Pass a closure as `combine` that returns the element
+  /// to use in the resulting array: The closure can choose between the two elements, combine them
+  /// to produce a new element, or even throw an error.
   ///
   /// - Parameters:
-  ///   - elements: A sequence of elements to use for the new array. Every key in `elements`
-  ///     must be unique.
+  ///   - elements: A sequence of elements to use for the new array. Every element in `elements`
+  ///     must have a unique id.
   ///   - id: The key path to an element's identifier.
-  /// - Returns: A new array initialized with the unique elements of `elements`.
-  /// - Complexity: Expected O(*n*) on average, where *n* is the count of elements, if `ID`
-  ///   implements high-quality hashing.
-  @inlinable
-  public init<S>(
-    arbitraryElements elements: S,
-    id: KeyPath<Element, ID>
-  )
-  where S: Sequence, S.Element == Element {
-    self.init(
-      arbitraryElements: elements,
-      id: id,
-      uniquingWith: { l, _ in l }
-    )
-  }
-
-  /// Creates a new array from the elements in the given sequence, using a combining closure to determine
-  ///  the element for any duplicate elements.
-  ///
-  /// You use this initializer to create an array when you have an arbitrary sequence of elements
-  /// that may not have unique ids. This initializer calls the combine closure with the current and
-  ///  new values for any duplicate ids. Pass a closure as combine that returns the value to use in
-  ///  the resulting dictionary: The closure can choose between the two values, combine them to produce
-  ///  a new value, or even throw an error.
-  ///
-  /// - Parameters:
-  ///   - elements: A sequence of elements to use for the new array. Every key in `elements`
-  ///     must be unique.
-  ///   - id: The key path to an element's identifier.
-  ///   - combine: Closure used to combine duplicated elements.
+  ///   - combine: Closure used to combine elements with duplicate ids.
   /// - Returns: A new array initialized with the unique elements of `elements`.
   /// - Complexity: Expected O(*n*) on average, where *n* is the count of elements, if `ID`
   ///   implements high-quality hashing.
   public init<S: Sequence>(
-    arbitraryElements elements: S,
+    _ elements: S,
     id: KeyPath<Element, ID>,
-    uniquingWith combine: (Element, Element) throws -> Element
+    uniquingElementsWith combine: (Element, Element) throws -> Element
   ) rethrows where S.Element == Element {
     try self.init(
       id: id,
@@ -209,34 +183,14 @@ extension IdentifiedArray where Element: Identifiable, ID == Element.ID {
     )
   }
 
-  /// Creates a new array from the elements in the given sequence.
+  /// Creates a new array from the elements in the given sequence, using a combining closure to
+  /// determine the element for any elements with duplicate ids.
   ///
   /// You use this initializer to create an array when you have an arbitrary sequence of elements
-  /// that may not have unique ids. It's safe to pass a sequence with duplicate ids to this initializer,
-  /// later duplicated elements will be discarded.
-  ///
-  /// - Parameters:
-  ///   - elements: A sequence of elements to use for the new array. Every key in `elements`
-  ///     must be unique.
-  /// - Returns: A new array initialized with the unique elements of `elements`.
-  /// - Complexity: Expected O(*n*) on average, where *n* is the count of elements, if `ID`
-  ///   implements high-quality hashing.
-  @inlinable
-  public init<S>(arbitraryElements elements: S) where S: Sequence, S.Element == Element {
-    self.init(
-      arbitraryElements: elements,
-      uniquingWith: { l, _ in l }
-    )
-  }
-
-  /// Creates a new array from the elements in the given sequence, using a combining closure to determine
-  ///  the element for any duplicate elements.
-  ///
-  /// You use this initializer to create an array when you have an arbitrary sequence of elements
-  /// that may not have unique ids. This initializer calls the combine closure with the current and
-  ///  new values for any duplicate ids. Pass a closure as combine that returns the value to use in
-  ///  the resulting dictionary: The closure can choose between the two values, combine them to produce
-  ///  a new value, or even throw an error.
+  /// that may not have unique ids. This initializer calls the `combine` closure with the current
+  /// and new elements for any duplicate ids. Pass a closure as `combine` that returns the element
+  /// to use in the resulting array: The closure can choose between the two elements, combine them
+  /// to produce a new element, or even throw an error.
   ///
   /// - Parameters:
   ///   - elements: A sequence of elements to use for the new array. Every key in `elements`
@@ -247,8 +201,8 @@ extension IdentifiedArray where Element: Identifiable, ID == Element.ID {
   ///   implements high-quality hashing.
   @inlinable
   public init<S: Sequence>(
-    arbitraryElements elements: S,
-    uniquingWith combine: (Element, Element) throws -> Element
+    _ elements: S,
+    uniquingElementsWith combine: (Element, Element) throws -> Element
   ) rethrows where S.Element == Element {
     try self.init(
       id: \.id,

--- a/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
+++ b/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
@@ -149,12 +149,7 @@ final class IdentifiedArrayTests: XCTestCase {
     XCTAssertEqual(IdentifiedArray(array[...]), [1, 2, 3])
   }
 
-  func testArbitraryInitId() {
-    let array = IdentifiedArray(arbitraryElements: ["A", "B", "C", "A"], id: \.self)
-    XCTAssertEqual(array, IdentifiedArray(uniqueElements: ["A", "B", "C"], id: \.self))
-  }
-
-  func testArbitraryInitIdCombined() {
+  func testInitIDUniquingElements() {
     struct Model: Equatable {
       let id: Int
       let data: String
@@ -162,11 +157,13 @@ final class IdentifiedArrayTests: XCTestCase {
     // Choose first element
     do {
       let array = IdentifiedArray(
-        arbitraryElements: [
+        [
           Model(id: 1, data: "A"),
           Model(id: 2, data: "B"),
           Model(id: 1, data: "AAAA"),
-        ], id: \.id, uniquingWith: { l, _ in l })
+        ],
+        id: \.id
+      ) { lhs, _ in lhs }
 
       XCTAssertEqual(
         array,
@@ -174,16 +171,21 @@ final class IdentifiedArrayTests: XCTestCase {
           uniqueElements: [
             Model(id: 1, data: "A"),
             Model(id: 2, data: "B"),
-          ], id: \.id))
+          ],
+          id: \.id
+        )
+      )
     }
     // Choose later element
     do {
       let array = IdentifiedArray(
-        arbitraryElements: [
+        [
           Model(id: 1, data: "A"),
           Model(id: 2, data: "B"),
           Model(id: 1, data: "AAAA"),
-        ], id: \.id, uniquingWith: { _, r in r })
+        ],
+        id: \.id
+      ) { _, rhs in rhs }
 
       XCTAssertEqual(
         array,
@@ -195,12 +197,7 @@ final class IdentifiedArrayTests: XCTestCase {
     }
   }
 
-  func testArbitraryInit() {
-    let array = IdentifiedArray(arbitraryElements: [1, 2, 3, 1])
-    XCTAssertEqual(array, [1, 2, 3])
-  }
-
-  func testArbitraryInitCombined() {
+  func testInitUniquingElements() {
     struct Model: Equatable, Identifiable {
       let id: Int
       let data: String
@@ -208,34 +205,42 @@ final class IdentifiedArrayTests: XCTestCase {
     // Choose first element
     do {
       let array = IdentifiedArray(
-        arbitraryElements: [
+        [
           Model(id: 1, data: "A"),
           Model(id: 2, data: "B"),
           Model(id: 1, data: "AAAA"),
-        ], uniquingWith: { l, _ in l })
+        ]
+      ) { lhs, _ in lhs }
 
       XCTAssertEqual(
         array,
-        IdentifiedArray(uniqueElements: [
-          Model(id: 1, data: "A"),
-          Model(id: 2, data: "B"),
-        ]))
+        IdentifiedArray(
+          uniqueElements: [
+            Model(id: 1, data: "A"),
+            Model(id: 2, data: "B"),
+          ]
+        )
+      )
     }
     // Choose later element
     do {
       let array = IdentifiedArray(
-        arbitraryElements: [
+        [
           Model(id: 1, data: "A"),
           Model(id: 2, data: "B"),
           Model(id: 1, data: "AAAA"),
-        ], uniquingWith: { _, r in r })
+        ]
+      ) { _, rhs in rhs }
 
       XCTAssertEqual(
         array,
-        IdentifiedArray(uniqueElements: [
-          Model(id: 1, data: "AAAA"),
-          Model(id: 2, data: "B"),
-        ]))
+        IdentifiedArray(
+          uniqueElements: [
+            Model(id: 1, data: "AAAA"),
+            Model(id: 2, data: "B"),
+          ]
+        )
+      )
     }
   }
 


### PR DESCRIPTION
This PR:

  - Removes the `init`s from #58 that don't specify a uniquing strategy
  - Renames `arbitraryElements:uniquingWith:` to `_:uniquingElementsWith:`.

/cc @alexito4