### PR TITLE
Make `Identified` conditionally `Sendable`

### DIFF
--- a/Sources/IdentifiedCollections/Identified/Identified.swift
+++ b/Sources/IdentifiedCollections/Identified/Identified.swift
@@ -59,6 +59,4 @@ extension Identified: Equatable where Value: Equatable {}
 
 extension Identified: Hashable where Value: Hashable {}
 
-#if canImport(_Concurrency) && compiler(>=5.5.2)
 extension Identified: Sendable where ID: Sendable, Value: Sendable {}
-#endif

--- a/Sources/IdentifiedCollections/Identified/Identified.swift
+++ b/Sources/IdentifiedCollections/Identified/Identified.swift
@@ -58,3 +58,7 @@ extension Identified: Encodable where ID: Encodable, Value: Encodable {}
 extension Identified: Equatable where Value: Equatable {}
 
 extension Identified: Hashable where Value: Hashable {}
+
+#if canImport(_Concurrency) && compiler(>=5.5.2)
+extension Identified: Sendable where ID: Sendable, Value: Sendable {}
+#endif


### PR DESCRIPTION
I'm not sure about the `compiler(>=5.5.2)` check. I think it was used to circumvent some compiler bug at some point, but I don't know if it still makes sense nowadays.