### PR TITLE
Add Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,27 @@ jobs:
     - uses: actions/checkout@v3
     - name: Run tests
       run: make test-linux
+
+  windows:
+    name: Windows
+    strategy:
+      matrix:
+        os: [windows-latest]
+        config: ['debug', 'release']
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: compnerd/gha-setup-swift@main
+        with:
+          branch: swift-5.8.1-release
+          tag: 5.8.1-RELEASE
+      - uses: actions/checkout@v3
+      - name: Build
+        run: swift build -c ${{ matrix.config }}
+      - name: Run tests (debug only)
+        # There is an issue that exists in the 5.8.1 toolchain
+        # which fails on release configuration testing, but
+        # this issue is fixed 5.9 so we can remove the if once
+        # that is generally available.
+        if: ${{ matrix.config == 'debug' }}
+        run: swift test

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,19 @@
 
 import PackageDescription
 
+var dependencies: [Package.Dependency] = [
+    .package(url: "https://github.com/apple/swift-collections", from: "1.0.2"),
+    .package(url: "https://github.com/apple/swift-collections-benchmark", from: "0.0.2"),
+]
+
+#if !os(Windows)
+// DocC needs to be ported to Windows
+// https://github.com/thebrowsercompany/swift-build/issues/39
+dependencies.append(
+  .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
+)
+#endif
+
 let package = Package(
   name: "swift-identified-collections",
   products: [
@@ -10,11 +23,7 @@ let package = Package(
       targets: ["IdentifiedCollections"]
     )
   ],
-  dependencies: [
-    .package(url: "https://github.com/apple/swift-collections", from: "1.0.2"),
-    .package(url: "https://github.com/apple/swift-collections-benchmark", from: "0.0.2"),
-    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-  ],
+  dependencies: dependencies,
   targets: [
     .target(
       name: "IdentifiedCollections",

--- a/Package.swift
+++ b/Package.swift
@@ -2,19 +2,6 @@
 
 import PackageDescription
 
-var dependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/apple/swift-collections", from: "1.0.2"),
-    .package(url: "https://github.com/apple/swift-collections-benchmark", from: "0.0.2"),
-]
-
-#if !os(Windows)
-// DocC needs to be ported to Windows
-// https://github.com/thebrowsercompany/swift-build/issues/39
-dependencies.append(
-  .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
-)
-#endif
-
 let package = Package(
   name: "swift-identified-collections",
   products: [
@@ -23,7 +10,10 @@ let package = Package(
       targets: ["IdentifiedCollections"]
     )
   ],
-  dependencies: dependencies,
+  dependencies: [
+    .package(url: "https://github.com/apple/swift-collections", from: "1.0.2"),
+    .package(url: "https://github.com/apple/swift-collections-benchmark", from: "0.0.2"),
+  ],
   targets: [
     .target(
       name: "IdentifiedCollections",
@@ -44,3 +34,11 @@ let package = Package(
     ),
   ]
 )
+
+#if !os(Windows)
+  // DocC needs to be ported to Windows
+  // https://github.com/thebrowsercompany/swift-build/issues/39
+  package.dependencies.append(
+    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
+  )
+#endif


### PR DESCRIPTION
This continues the journey of adding Windows CI to all leaf dependencies that TCA uses. There are some issues with DocC and build plugins in general with the Swift for Windows toolchain for the time being so I've only kept that dependency available for non-Windows builds so that documentation can still be built.