### PR TITLE
Fix subscript setter

### DIFF
--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+MutableCollection.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+MutableCollection.swift
@@ -6,10 +6,12 @@ extension IdentifiedArray: MutableCollection {
   public subscript(position: Int) -> Element {
     _read { yield self._dictionary.elements.values[position] }
     set {
+      self._dictionary.remove(at: position)
       let key = _id(newValue)
-      if self._dictionary.keys.contains(key) {
-        self._dictionary.removeValue(forKey: key)
-      }
+      precondition(
+        !self._dictionary.keys.contains(key),
+        "Collection already contains element with this identity"
+      )
       self._dictionary.updateValue(newValue, forKey: key, insertingAt: position)
     }
     _modify {

--- a/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
+++ b/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
@@ -368,4 +368,14 @@ final class IdentifiedArrayTests: XCTestCase {
       })
     })
   }
+
+  func testIdentifiedArraySubscript() {
+    struct Item: Identifiable {
+      let id: Int
+    }
+    var items: IdentifiedArrayOf<Item> = [Item(id: 1), Item(id: 2), Item(id: 3)]
+    items[1] = Item(id: 4)
+    XCTAssertEqual(3, items.count)
+    XCTAssertEqual([1, 4, 3], items.map(\.id))
+  }
 }


### PR DESCRIPTION
The `set`/`modify` of `identifiedArray[n]` both assume an in-place replacement of the same identity. This makes sense for `_modify`, but not `set`, which can replace a value with one that has a totally new identity.