### PR TITLE
Fix subscript set operation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,24 +11,31 @@ on:
 jobs:
   build:
     name: MacOS
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
-    - uses: actions/checkout@v3
-    - name: Select Xcode 14.2
-      run: sudo xcode-select -s /Applications/Xcode_14.2.app
+    - uses: actions/checkout@v4
+    - name: Select Xcode 15.2
+      run: sudo xcode-select -s /Applications/Xcode_15.2.app
     - name: Run tests
       run: make test-swift
 
   ubuntu:
-    name: Ubuntu
+    strategy:
+      matrix:
+        swift:
+          - '5.9'
+    name: Ubuntu (Swift ${{ matrix.swift }})
     runs-on: ubuntu-latest
+    container: swift:${{ matrix.swift }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run tests
-      run: make test-linux
+      run: swift test --parallel
+    - name: Run tests (release)
+      run: swift test -c release --parallel
 
   windows:
-    name: Windows
+    name: Windows (Swift ${{ matrix.swfit }}, ${{ matrix.config }})
     strategy:
       matrix:
         os: [windows-latest]
@@ -38,15 +45,11 @@ jobs:
     steps:
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-5.8.1-release
-          tag: 5.8.1-RELEASE
-      - uses: actions/checkout@v3
+          branch: swift-5.9.1-release
+          tag: 5.9.1-RELEASE
+      - uses: actions/checkout@v4
       - name: Build
         run: swift build -c ${{ matrix.config }}
       - name: Run tests (debug only)
-        # There is an issue that exists in the 5.8.1 toolchain
-        # which fails on release configuration testing, but
-        # this issue is fixed 5.9 so we can remove the if once
-        # that is generally available.
         if: ${{ matrix.config == 'debug' }}
         run: swift test

--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+MutableCollection.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+MutableCollection.swift
@@ -6,13 +6,14 @@ extension IdentifiedArray: MutableCollection {
   public subscript(position: Int) -> Element {
     _read { yield self._dictionary.elements.values[position] }
     set {
-      self._dictionary.remove(at: position)
       let key = _id(newValue)
-      precondition(
-        !self._dictionary.keys.contains(key),
-        "Collection already contains element with this identity"
-      )
-      self._dictionary.updateValue(newValue, forKey: key, insertingAt: position)
+      if let index = self._dictionary.keys.firstIndex(of: key) {
+        self._dictionary.swapAt(index, position)
+        self._dictionary.updateValue(newValue, forKey: key)
+      } else {
+        self._dictionary.remove(at: position)
+        self._dictionary.updateValue(newValue, forKey: key, insertingAt: position)
+      }
     }
     _modify {
       yield &self._dictionary.elements.values[position]

--- a/Tests/IdentifiedCollectionsTests/IdentifiedArrayCollectionOperationTests.swift
+++ b/Tests/IdentifiedCollectionsTests/IdentifiedArrayCollectionOperationTests.swift
@@ -1,0 +1,66 @@
+import IdentifiedCollections
+import XCTest
+
+final class IdentifiedArrayCollectionOperationsTests: XCTestCase {
+  func testReverse() {
+    assertElementsEqual { $0.reverse() }
+  }
+  func testSort() {
+    assertElementsEqual { $0.sort() }
+  }
+}
+
+private struct Item: Identifiable, Comparable, Equatable {
+  let id = UUID()
+  var count: Int
+
+  static func < (lhs: Self, rhs: Self) -> Bool {
+    lhs.count < rhs.count
+  }
+}
+
+private protocol TestCollection<Element>:
+MutableCollection, RandomAccessCollection, RangeReplaceableCollection {}
+
+extension Array: TestCollection {}
+extension IdentifiedArray: TestCollection where Element: Identifiable, Element.ID == ID {}
+
+private func assertElementsEqual(
+  after operation: (inout (any TestCollection<Item>)) -> Void,
+  file: StaticString = #file,
+  line: UInt = #line
+) {
+  for n in 0...10 {
+    let size = Int(pow(Double(n), 2))
+    for _ in 1...10 {
+      var identifiedArray: IdentifiedArrayOf<Item> = []
+      for _ in 0..<size {
+        identifiedArray.append(Item(count: .random(in: -1_000...1_000)))
+      }
+      var anyIdentifiedArray = identifiedArray as any TestCollection<Item>
+      var anyArray = Array(identifiedArray) as any TestCollection<Item>
+      operation(&anyIdentifiedArray)
+      operation(&anyArray)
+      XCTAssert(
+        anyIdentifiedArray.elementsEqual(anyArray),
+        """
+        (\(anyIdentifiedArray)) does not equal control (\(anyArray))
+        """,
+        file: file,
+        line: line
+      )
+      identifiedArray = anyIdentifiedArray as! IdentifiedArrayOf<Item>
+      XCTAssert(
+        identifiedArray.ids.elementsEqual(identifiedArray.map(\.id)),
+        """
+        (\(identifiedArray.ids)) keys does not equal IDs (\(identifiedArray.map(\.id)))
+        """,
+        file: file,
+        line: line
+      )
+      if size == 0 {
+        continue
+      }
+    }
+  }
+}

--- a/Tests/IdentifiedCollectionsTests/IdentifiedArrayCollectionOperationTests.swift
+++ b/Tests/IdentifiedCollectionsTests/IdentifiedArrayCollectionOperationTests.swift
@@ -8,6 +8,9 @@ final class IdentifiedArrayCollectionOperationsTests: XCTestCase {
   func testSort() {
     assertElementsEqual { $0.sort() }
   }
+  func testSortUsing() {
+    assertElementsEqual { $0.sort(using: KeyPathComparator(\.count)) }
+  }
 }
 
 private struct Item: Identifiable, Comparable, Equatable {

--- a/Tests/IdentifiedCollectionsTests/IdentifiedArrayCollectionOperationTests.swift
+++ b/Tests/IdentifiedCollectionsTests/IdentifiedArrayCollectionOperationTests.swift
@@ -2,15 +2,40 @@ import IdentifiedCollections
 import XCTest
 
 final class IdentifiedArrayCollectionOperationsTests: XCTestCase {
+  func testMax() {
+    assertElementsEqual { $0.max() }
+    assertElementsEqual { $0.max(by: >) }
+  }
+  func testMin() {
+    assertElementsEqual { $0.min() }
+    assertElementsEqual { $0.min(by: >) }
+  }
+  func testRemoveFirst() {
+    assertElementsEqual { $0.isEmpty ? nil : $0.removeFirst() }
+  }
+  func testRemoveLast() {
+    assertElementsEqual { $0.isEmpty ? nil : $0.removeLast() }
+  }
   func testReverse() {
     assertElementsEqual { $0.reverse() }
   }
+  func testShuffleUsing() {
+    var seed: UInt64 = 0
+    assertElementsEqual {
+      var rng = LCRNG(seed: seed)
+      $0.shuffle(using: &rng)
+    } setUp: {
+      seed = .random(in: .min ... .max)
+    }
+  }
   func testSort() {
     assertElementsEqual { $0.sort() }
+    assertElementsEqual { $0.sort(by: >) }
   }
   #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
     func testSortUsing() {
       assertElementsEqual { $0.sort(using: KeyPathComparator(\.count)) }
+      assertElementsEqual { $0.sort(using: KeyPathComparator(\.count, order: .reverse)) }
     }
   #endif
 }
@@ -30,22 +55,24 @@ MutableCollection, RandomAccessCollection, RangeReplaceableCollection {}
 extension Array: TestCollection {}
 extension IdentifiedArray: TestCollection where Element: Identifiable, Element.ID == ID {}
 
-private func assertElementsEqual(
-  after operation: (inout (any TestCollection<Item>)) -> Void,
+private func assertElementsEqual<Result>(
+  after operation: (inout (any TestCollection<Item>)) -> Result,
+  setUp: () -> Void = {},
   file: StaticString = #file,
   line: UInt = #line
 ) {
   for n in 0...10 {
     let size = Int(pow(Double(n), 2))
     for _ in 1...10 {
+      setUp()
       var identifiedArray: IdentifiedArrayOf<Item> = []
       for _ in 0..<size {
         identifiedArray.append(Item(count: .random(in: -1_000...1_000)))
       }
       var anyIdentifiedArray = identifiedArray as any TestCollection<Item>
       var anyArray = Array(identifiedArray) as any TestCollection<Item>
-      operation(&anyIdentifiedArray)
-      operation(&anyArray)
+      let lhs = operation(&anyIdentifiedArray)
+      let rhs = operation(&anyArray)
       XCTAssert(
         anyIdentifiedArray.elementsEqual(anyArray),
         """
@@ -63,9 +90,28 @@ private func assertElementsEqual(
         file: file,
         line: line
       )
+      if let lhs = lhs as? any Equatable {
+        func open<LHS: Equatable>(_ lhs: LHS) {
+          if let rhs = rhs as? LHS {
+            XCTAssertEqual(lhs, rhs, file: file, line: line)
+          }
+        }
+        open(lhs)
+      }
       if size == 0 {
         continue
       }
     }
+  }
+}
+
+struct LCRNG: RandomNumberGenerator {
+  var seed: UInt64
+  init(seed: UInt64 = 0) {
+    self.seed = seed
+  }
+  mutating func next() -> UInt64 {
+    self.seed = 2_862_933_555_777_941_757 &* self.seed &+ 3_037_000_493
+    return self.seed
   }
 }

--- a/Tests/IdentifiedCollectionsTests/IdentifiedArrayCollectionOperationTests.swift
+++ b/Tests/IdentifiedCollectionsTests/IdentifiedArrayCollectionOperationTests.swift
@@ -8,9 +8,11 @@ final class IdentifiedArrayCollectionOperationsTests: XCTestCase {
   func testSort() {
     assertElementsEqual { $0.sort() }
   }
-  func testSortUsing() {
-    assertElementsEqual { $0.sort(using: KeyPathComparator(\.count)) }
-  }
+  #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    func testSortUsing() {
+      assertElementsEqual { $0.sort(using: KeyPathComparator(\.count)) }
+    }
+  #endif
 }
 
 private struct Item: Identifiable, Comparable, Equatable {

--- a/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
+++ b/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
@@ -378,4 +378,13 @@ final class IdentifiedArrayTests: XCTestCase {
     XCTAssertEqual(3, items.count)
     XCTAssertEqual([1, 4, 3], items.map(\.id))
   }
+
+  func testIdentifiedArrayComparatorSort() {
+    struct Item: Identifiable {
+      let id: Int
+    }
+    var items: IdentifiedArrayOf<Item> = [Item(id: 3), Item(id: 2), Item(id: 1)]
+    items.sort(using: KeyPathComparator(\.id))
+    XCTAssertEqual([1, 2, 3], items.map(\.id))
+  }
 }

--- a/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
+++ b/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
@@ -379,12 +379,14 @@ final class IdentifiedArrayTests: XCTestCase {
     XCTAssertEqual([1, 4, 3], items.map(\.id))
   }
 
-  func testIdentifiedArrayComparatorSort() {
-    struct Item: Identifiable {
-      let id: Int
+  #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+    func testIdentifiedArrayComparatorSort() {
+      struct Item: Identifiable {
+        let id: Int
+      }
+      var items: IdentifiedArrayOf<Item> = [Item(id: 3), Item(id: 2), Item(id: 1)]
+      items.sort(using: KeyPathComparator(\.id))
+      XCTAssertEqual([1, 2, 3], items.map(\.id))
     }
-    var items: IdentifiedArrayOf<Item> = [Item(id: 3), Item(id: 2), Item(id: 1)]
-    items.sort(using: KeyPathComparator(\.id))
-    XCTAssertEqual([1, 2, 3], items.map(\.id))
-  }
+  #endif
 }


### PR DESCRIPTION
PR #66 fixed one issue but introduced a regression. This PR changes the subscript setter to do a `swap` when identity of elements match something that already exists in the collection.

I've also stubbed out a fake property testing suite that can hopefully be expanded with more operations soon.

Fixes #69.