### PR TITLE
Swift Language Support: Drop <5.9, Add 6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,12 @@ on:
 
 jobs:
   build:
-    name: MacOS
-    runs-on: macos-13
+    name: macOS
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
-    - name: Select Xcode 15.2
-      run: sudo xcode-select -s /Applications/Xcode_15.2.app
+    - name: Select Xcode 15.4
+      run: sudo xcode-select -s /Applications/Xcode_15.4.app
     - name: Run tests
       run: make test-swift
 
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         swift:
-          - '5.9'
+          - '5.10'
     name: Ubuntu (Swift ${{ matrix.swift }})
     runs-on: ubuntu-latest
     container: swift:${{ matrix.swift }}
@@ -35,7 +35,7 @@ jobs:
       run: swift test -c release --parallel
 
   windows:
-    name: Windows (Swift ${{ matrix.swfit }}, ${{ matrix.config }})
+    name: Windows (Swift ${{ matrix.swift }}, ${{ matrix.config }})
     strategy:
       matrix:
         os: [windows-latest]
@@ -45,8 +45,8 @@ jobs:
     steps:
       - uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-5.9.1-release
-          tag: 5.9.1-RELEASE
+          branch: swift-5.10-release
+          tag: 5.10-RELEASE
       - uses: actions/checkout@v4
       - name: Build
         run: swift build -c ${{ matrix.config }}

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 
 import PackageDescription
 
@@ -32,15 +32,9 @@ let package = Package(
         .product(name: "CollectionsBenchmark", package: "swift-collections-benchmark"),
       ]
     ),
-  ]
+  ],
+  swiftLanguageVersions: [.v6]
 )
-
-for target in package.targets {
-  target.swiftSettings = target.swiftSettings ?? []
-  target.swiftSettings!.append(contentsOf: [
-    .enableExperimentalFeature("StrictConcurrency")
-  ])
-}
 
 #if !os(Windows)
   // DocC needs to be ported to Windows

--- a/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Sendable.swift
+++ b/Sources/IdentifiedCollections/IdentifiedArray/IdentifiedArray+Sendable.swift
@@ -1,4 +1,2 @@
-#if swift(>=5.5)
-  extension IdentifiedArray: @unchecked Sendable
-  where ID: Sendable, Element: Sendable {}
-#endif
+extension IdentifiedArray: @unchecked Sendable
+where ID: Sendable, Element: Sendable {}

--- a/Sources/swift-identified-collections-benchmark/main.swift
+++ b/Sources/swift-identified-collections-benchmark/main.swift
@@ -1,8 +1,13 @@
 import CollectionsBenchmark
 import IdentifiedCollections
 
-@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
-extension Int: Identifiable { public var id: Self { self } }
+#if $RetroactiveAttribute
+  @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+  extension Int: @retroactive Identifiable { public var id: Self { self } }
+#else
+  @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
+  extension Int: Identifiable { public var id: Self { self } }
+#endif
 
 if #available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *) {
   var benchmark = Benchmark(title: "Identified Collections Benchmark")

--- a/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
+++ b/Tests/IdentifiedCollectionsTests/IdentifiedArrayTests.swift
@@ -2,7 +2,11 @@ import XCTest
 
 @testable import IdentifiedCollections
 
-extension Int: Identifiable { public var id: Self { self } }
+#if $RetroactiveAttribute
+  extension Int: @retroactive Identifiable { public var id: Self { self } }
+#else
+  extension Int: Identifiable { public var id: Self { self } }
+#endif
 
 private struct User: Equatable, Identifiable {
   let id: Int


### PR DESCRIPTION
We can drop Swift <5.9 now that the App Store requires Xcode 15 for submissions, and we can add 6.0 language mode to keep our concurrency story in check.