### PR TITLE
use swiftLanguageModes instead of swiftLanguageVersions

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -33,7 +33,7 @@ let package = Package(
       ]
     ),
   ],
-  swiftLanguageVersions: [.v6]
+  swiftLanguageModes: [.v6]
 )
 
 #if !os(Windows)


### PR DESCRIPTION
In Swift 6  using `swiftLanguageVersions` raises warnings since it was deprecated

https://developer.apple.com/documentation/packagedescription/package/swiftlanguageversions