### PR TITLE
Fix documentation link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     url: https://github.com/pointfreeco/swift-identified-collections/discussions
     about: Identified Collections Q&A, ideas, and more
   - name: Documentation
-    url: https://pointfreeco.github.io/swift-identified-collections/main/documentation/identifiedcollections/
+    url: https://swiftpackageindex.com/pointfreeco/swift-identified-collections/main/documentation/identifiedcollections
     about: Read Identified Collections' documentation
   - name: Videos
     url: https://www.pointfree.co/


### PR DESCRIPTION
Updates the issue template documentation contact link to the Swift Package Index DocC URL.